### PR TITLE
[#10] 네트워크 로직에 필요한 객체 구현해요

### DIFF
--- a/MedicalCenterSearcher/MedicalCenterSearcher.xcodeproj/project.pbxproj
+++ b/MedicalCenterSearcher/MedicalCenterSearcher.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		5C6559C4AAD065D6C0B664AF /* Pods_MedicalCenterSearcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3825F344525D5629C938D7E5 /* Pods_MedicalCenterSearcher.framework */; };
+		B4AFA0D828FBF691001429C0 /* CenterInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AFA0D728FBF691001429C0 /* CenterInfo.swift */; };
+		B4AFA0DA28FBF95A001429C0 /* NetworkRequestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AFA0D928FBF95A001429C0 /* NetworkRequestRouter.swift */; };
+		B4AFA0DC28FC009F001429C0 /* APINetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AFA0DB28FC009F001429C0 /* APINetworkError.swift */; };
 		B4E4870228F9714E00B659FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E4870128F9714E00B659FD /* AppDelegate.swift */; };
 		B4E4870428F9714E00B659FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E4870328F9714E00B659FD /* SceneDelegate.swift */; };
 		B4E4870B28F9715000B659FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B4E4870A28F9715000B659FD /* Assets.xcassets */; };
@@ -29,6 +32,9 @@
 		3825F344525D5629C938D7E5 /* Pods_MedicalCenterSearcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MedicalCenterSearcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		71D79C18CA87A3F8DDA50C4D /* Pods-MedicalCenterSearcher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MedicalCenterSearcher.debug.xcconfig"; path = "Target Support Files/Pods-MedicalCenterSearcher/Pods-MedicalCenterSearcher.debug.xcconfig"; sourceTree = "<group>"; };
 		87130B76ADE629BA8E5D9CEC /* Pods-MedicalCenterSearcher.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MedicalCenterSearcher.release.xcconfig"; path = "Target Support Files/Pods-MedicalCenterSearcher/Pods-MedicalCenterSearcher.release.xcconfig"; sourceTree = "<group>"; };
+		B4AFA0D728FBF691001429C0 /* CenterInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterInfo.swift; sourceTree = "<group>"; };
+		B4AFA0D928FBF95A001429C0 /* NetworkRequestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequestRouter.swift; sourceTree = "<group>"; };
+		B4AFA0DB28FC009F001429C0 /* APINetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APINetworkError.swift; sourceTree = "<group>"; };
 		B4E486FE28F9714E00B659FD /* MedicalCenterSearcher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MedicalCenterSearcher.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4E4870128F9714E00B659FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B4E4870328F9714E00B659FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -176,7 +182,10 @@
 		B4E4872A28F98EF700B659FD /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				B4AFA0DB28FC009F001429C0 /* APINetworkError.swift */,
 				B4E4872B28F98F0E00B659FD /* NetworkManager.swift */,
+				B4AFA0D928FBF95A001429C0 /* NetworkRequestRouter.swift */,
+				B4AFA0D728FBF691001429C0 /* CenterInfo.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -323,7 +332,10 @@
 				B4E4872028F98AA900B659FD /* CenterInfoViewModel.swift in Sources */,
 				B4E4870428F9714E00B659FD /* SceneDelegate.swift in Sources */,
 				B4E4871E28F98A9C00B659FD /* CenterInfoViewController.swift in Sources */,
+				B4AFA0DA28FBF95A001429C0 /* NetworkRequestRouter.swift in Sources */,
 				B4E4872228F98ABA00B659FD /* MapViewController.swift in Sources */,
+				B4AFA0D828FBF691001429C0 /* CenterInfo.swift in Sources */,
+				B4AFA0DC28FC009F001429C0 /* APINetworkError.swift in Sources */,
 				B4E4872428F98AC500B659FD /* MapViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MedicalCenterSearcher/MedicalCenterSearcher/Network/APINetworkError.swift
+++ b/MedicalCenterSearcher/MedicalCenterSearcher/Network/APINetworkError.swift
@@ -1,0 +1,22 @@
+//
+//  APINetworkError.swift
+//  MedicalCenterSearcher
+//
+//  Created by 김민성 on 2022/10/16.
+//
+
+import Foundation
+
+enum APINetworkError: Error {
+  case networkError
+  case decodingError
+
+  var message: String {
+    switch self {
+    case .networkError:
+      return "네트워크 상태를 확인해주세요."
+    case .decodingError:
+      return "원하는 값으로 변환할 수 없습니다."
+    }
+  }
+}

--- a/MedicalCenterSearcher/MedicalCenterSearcher/Network/CenterInfo.swift
+++ b/MedicalCenterSearcher/MedicalCenterSearcher/Network/CenterInfo.swift
@@ -1,0 +1,27 @@
+//
+//  CenterInfo.swift
+//  MedicalCenterSearcher
+//
+//  Created by 김민성 on 2022/10/16.
+//
+
+import Foundation
+
+struct CenterInfo: Decodable {
+  var page: Int
+  var perPage: Int
+  var totalCount: Int
+  var currentCount: Int
+  var matchCount: Int
+  var data: [CenterModel]
+}
+
+struct CenterModel: Decodable {
+  var centerName: String
+  var facilityName: String
+  var address: String
+  var lat: String
+  var lng: String
+  var phoneNumber: String
+  var updatedAt: String
+}

--- a/MedicalCenterSearcher/MedicalCenterSearcher/Network/NetworkManager.swift
+++ b/MedicalCenterSearcher/MedicalCenterSearcher/Network/NetworkManager.swift
@@ -9,4 +9,29 @@ import Alamofire
 import RxSwift
 
 struct NetworkManager {
+
+  func fetchAllCenterData() -> Single<Result<CenterInfo,APINetworkError>> {
+    return Single.create { observer -> Disposable in
+      AF.request(NetworkRequestRouter.fetchAllCenterDate)
+        .validate()
+        .response { response in
+          switch response.result {
+          case .success(let data):
+            guard let data = data else { return }
+            if let response = convertedResponse(data: data) {
+              observer(.success(.success(response)))
+            } else {
+              observer(.success(.failure(APINetworkError.decodingError)))
+            }
+          case .failure(_):
+            observer(.success(.failure(APINetworkError.networkError)))
+          }
+        }
+      return Disposables.create()
+    }
+  }
+
+    func convertedResponse(data: Data) -> CenterInfo? {
+        return try? JSONDecoder().decode(CenterInfo.self, from: data)
+  }
 }

--- a/MedicalCenterSearcher/MedicalCenterSearcher/Network/NetworkRequestRouter.swift
+++ b/MedicalCenterSearcher/MedicalCenterSearcher/Network/NetworkRequestRouter.swift
@@ -1,0 +1,42 @@
+//
+//  NetworkRequestRouter.swift
+//  MedicalCenterSearcher
+//
+//  Created by 김민성 on 2022/10/16.
+//
+
+import Foundation
+
+import Alamofire
+
+enum NetworkRequestRouter: URLRequestConvertible {
+
+  case fetchAllCenterDate
+
+  private var baseURLString: String {
+    return "api.odcloud.kr/api/15077586/v1"
+  }
+
+  private var path: String {
+    switch self {
+    case .fetchAllCenterDate:
+      return "/centers?page=1&perPage=10&serviceKey=zTlMijyX4v2prsaIl46HMBmskiLMPnJuL2ryOhY+bGw2lS3HEU1xJq8I5833Oj24q5NzIWJtRch++R8G3tsUkQ=="
+    }
+  }
+
+  private var HTTPMethod: Alamofire.HTTPMethod {
+    return .get
+  }
+
+  func asURLRequest() throws -> URLRequest {
+    let url = try (self.baseURLString + self.path).asURL()
+    var request = URLRequest(url: url)
+    request.httpMethod = self.HTTPMethod.rawValue
+    request.cachePolicy = .reloadIgnoringCacheData
+
+    switch self {
+    case .fetchAllCenterDate:
+      return request
+    }
+  }
+}


### PR DESCRIPTION
## 배경
- #10 
- 네트워킹에 필요한 로직을 구현해요
## 수정내역
- Request를 구성할 NetworkRequestRouter를 구현했어요
- 네트워킹 로직에서 필요한 Error타입을 정의했어요
- 필요한 Entity를 구현했어요
- 네트워킹을 실행하는 NetworkManager를 구현했어요
## 리뷰노트
- API호출 key가 동작하지 않아 테스트를 진행하지 못했어요